### PR TITLE
raise exception if n=1 is used in parallel analytical mechanism

### DIFF
--- a/pyropy/pyrolysis.py
+++ b/pyropy/pyrolysis.py
@@ -278,6 +278,10 @@ class PyrolysisParallelAnalytical(Pyrolysis):
         for idx in range(0, self.reaction_scheme_obj.n_reactions):
             xi_init = 0
             n = self.reaction_scheme_obj.dict_params["n"][idx]
+
+            if n == 1:
+                raise ZeroDivisionError("n cannot be equal to 1 in this mechanism!")
+
             A = 10 ** self.reaction_scheme_obj.dict_params["A"][idx]
             E = self.reaction_scheme_obj.dict_params["E"][idx]
 

--- a/pyropy/tests/test_parallel.py
+++ b/pyropy/tests/test_parallel.py
@@ -78,3 +78,18 @@ def test_parallel_scheme_analytical(reactions: ReactManager):
     )
 
     np.testing.assert_allclose(test.rho_solid, solution_known, rtol=1e-05)
+
+
+def test_parallel_scheme_analytical_division_0(reactions: ReactManager):
+    with pytest.raises(ZeroDivisionError):
+        T_0 = 373
+        T_end = 2000
+        b = 20
+        reactions.react_reader()
+        reactions.param_reader()
+        reactions.dict_params["n"] = [1, 1]  # setting n parameter to 1 to force the division by 0 error
+        test = PyrolysisParallelAnalytical(
+            temp_0=T_0, temp_end=T_end, beta=b, n_points=15, reaction_scheme_obj=reactions
+        )
+        # Numerical solution using 200 points
+        test.solve_system()


### PR DESCRIPTION
Fixes #7.
Indeed, I have added an exception for that and a test to check it. 
